### PR TITLE
Updated KissXML dependency to 5.2.2 to fix issues with Xcode 9.3.

### DIFF
--- a/XMPPFramework.podspec
+++ b/XMPPFramework.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     ss.resources = [ 'Extensions/**/*.{xcdatamodel,xcdatamodeld}']
 	  ss.dependency 'CocoaLumberjack' # Skip pinning version because of the awkward 2.x->3.x transition
 	  ss.dependency 'CocoaAsyncSocket', '~> 7.6.0'
-	  ss.dependency 'KissXML', '~> 5.2.0'
+	  ss.dependency 'KissXML', '~> 5.2.2'
 	  ss.dependency 'libidn', '~> 1.33.0'
   end
 


### PR DESCRIPTION
Please also update the submodule reference to this in ChatSecure!